### PR TITLE
Add license tag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setuptools.setup(
     author="Bouni",
     author_email="bouni@owee.de",
     description="A library to fetch data from the Swiss federal Office for Environment FEON",
+    license="MIT",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/bouni/swisshydrodata",


### PR DESCRIPTION
Allow third-party tools (e. g., PyPI or `pyp2rpm`) to get the license details in a simple way.